### PR TITLE
Update version to 2.5.0-alpha.4+26.2

### DIFF
--- a/src/client/java/top/windysky/minecarttrainsfork/client/extension/config/ClientConfigValue.java
+++ b/src/client/java/top/windysky/minecarttrainsfork/client/extension/config/ClientConfigValue.java
@@ -53,7 +53,7 @@ public class ClientConfigValue implements ConfigData {
     // Height of head particle
     @ConfigEntry.Category("advanced")
     @ConfigEntry.BoundedDiscrete(min = 1, max = 20)
-    public int headParticleHeight = 8;
+    public int headParticleHeight = 14;
 
     // Cycle of head particle
     @ConfigEntry.Category("advanced")

--- a/src/client/java/top/windysky/minecarttrainsfork/client/extension/config/ClientConfigValue.java
+++ b/src/client/java/top/windysky/minecarttrainsfork/client/extension/config/ClientConfigValue.java
@@ -39,9 +39,13 @@ public class ClientConfigValue implements ConfigData {
     @ConfigEntry.BoundedDiscrete(min = 1, max = 10)
     public int lineWidth = 5;
 
-    // Head particle type
+    // Always render head particle
     @ConfigEntry.Category("advanced")
     @ConfigEntry.Gui.PrefixText
+    public boolean alwaysRenderHeadParticle = false;
+
+    // Head particle type
+    @ConfigEntry.Category("advanced")
     @ConfigEntry.ColorPicker
     public ParticleOption headParticleType = ParticleOption.composter;
 

--- a/src/client/java/top/windysky/minecarttrainsfork/client/manager/ClientConfigManager.java
+++ b/src/client/java/top/windysky/minecarttrainsfork/client/manager/ClientConfigManager.java
@@ -29,6 +29,10 @@ public class ClientConfigManager {
         return config.lineWidth * 0.01;
     }
 
+    public static boolean isAlwaysRenderHeadParticle() {
+        return config.alwaysRenderHeadParticle;
+    }
+
     public static @NonNull SimpleParticleType getHeadParticleType() {
         return config.headParticleType.getType();
     }

--- a/src/client/java/top/windysky/minecarttrainsfork/client/manager/ParticleManager.java
+++ b/src/client/java/top/windysky/minecarttrainsfork/client/manager/ParticleManager.java
@@ -199,6 +199,14 @@ public class ParticleManager {
             return;
         }
 
+        UUID childCartUuid = ((IChainableUtil) cart).getChildUUID();
+
+        if (!ClientLoadManager.isAPIFound() || !ClientConfigManager.isAlwaysRenderHeadParticle()) {
+            if (childCartUuid == null || world.getEntity(childCartUuid) == null) {
+                return;
+            }
+        }
+
         final int FRAME_SKIP = frameSkip;
         final int MAX_STEPS = maxSteps;
         final double PARTICLE_HEIGHT = particleHeight;

--- a/src/client/java/top/windysky/minecarttrainsfork/client/manager/ParticleManager.java
+++ b/src/client/java/top/windysky/minecarttrainsfork/client/manager/ParticleManager.java
@@ -239,6 +239,8 @@ public class ParticleManager {
             frameSkip = ClientConfigManager.getLinkParticleCycle();
             particleType = ClientConfigManager.getLinkParticleType();
             particleHeight = ClientConfigManager.getLinkParticleHeight();
+        } else {
+            return;
         }
 
         if (cart == null || !(cart.level() instanceof ClientLevel world)) {

--- a/src/client/java/top/windysky/minecarttrainsfork/client/manager/ParticleManager.java
+++ b/src/client/java/top/windysky/minecarttrainsfork/client/manager/ParticleManager.java
@@ -202,7 +202,7 @@ public class ParticleManager {
         UUID childCartUuid = ((IChainableUtil) cart).getChildUUID();
 
         if (!ClientLoadManager.isAPIFound() || !ClientConfigManager.isAlwaysRenderHeadParticle()) {
-            if (childCartUuid == null || world.getEntity(childCartUuid) == null) {
+            if (cart.isVehicle() || childCartUuid == null || world.getEntity(childCartUuid) == null) {
                 return;
             }
         }

--- a/src/main/java/top/windysky/minecarttrainsfork/manager/EventManager.java
+++ b/src/main/java/top/windysky/minecarttrainsfork/manager/EventManager.java
@@ -10,7 +10,6 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
@@ -65,7 +64,7 @@ public class EventManager {
 
                         IChainableUtil.setChainedParentChild(parentIChainable, cartIChainable);
 
-                        NetworkManager.sendRelationshipPayload(cart.getUUID(), parent.getUUID(), (ServerPlayer) player);
+                        NetworkManager.sendRelationshipPayload(cart.getUUID(), parent.getUUID(), world);
                     }
                 } else {
                     stack.remove(parentID);
@@ -100,7 +99,7 @@ public class EventManager {
 
             if (!world.isClientSide()) {
                 ServerLevel serverWorld = (ServerLevel)world;
-                UnLinkUtil.unlinkHandle(icu, serverWorld, player);
+                UnLinkUtil.unlinkHandle(icu, serverWorld);
             }
 
             return InteractionResult.SUCCESS;

--- a/src/main/java/top/windysky/minecarttrainsfork/manager/NetworkManager.java
+++ b/src/main/java/top/windysky/minecarttrainsfork/manager/NetworkManager.java
@@ -19,7 +19,12 @@ public class NetworkManager {
         }
 
         RelationshipPayload relationship = new RelationshipPayload(childUUID, parentUUID);
-        ServerPlayNetworking.send(player, relationship);
+        
+        for (ServerPlayer p : player.level().getServer().getPlayerList().getPlayers()) {
+            if (p != null) {
+                ServerPlayNetworking.send(p, relationship);
+            }
+        }
     }
 
     public record RelationshipPayload(UUID childUUID, UUID parentUUID) implements CustomPacketPayload {

--- a/src/main/java/top/windysky/minecarttrainsfork/manager/NetworkManager.java
+++ b/src/main/java/top/windysky/minecarttrainsfork/manager/NetworkManager.java
@@ -9,20 +9,20 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
 
 public class NetworkManager {
 
-    public static void sendRelationshipPayload(UUID childUUID, UUID parentUUID, ServerPlayer player) {
-        if (player == null) {
+    public static void sendRelationshipPayload(UUID childUUID, UUID parentUUID, Level level) {
+        if (level == null || !(level instanceof ServerLevel serverLevel)) {
             return;
         }
 
-        RelationshipPayload relationship = new RelationshipPayload(childUUID, parentUUID);
-
-        for (ServerPlayer p : player.level().getServer().getPlayerList().getPlayers()) {
+        for (ServerPlayer p : serverLevel.getServer().getPlayerList().getPlayers()) {
             if (p != null) {
-                ServerPlayNetworking.send(p, relationship);
+                ServerPlayNetworking.send(p, new RelationshipPayload(childUUID, parentUUID));
             }
         }
     }

--- a/src/main/java/top/windysky/minecarttrainsfork/manager/NetworkManager.java
+++ b/src/main/java/top/windysky/minecarttrainsfork/manager/NetworkManager.java
@@ -19,7 +19,7 @@ public class NetworkManager {
         }
 
         RelationshipPayload relationship = new RelationshipPayload(childUUID, parentUUID);
-        
+
         for (ServerPlayer p : player.level().getServer().getPlayerList().getPlayers()) {
             if (p != null) {
                 ServerPlayNetworking.send(p, relationship);

--- a/src/main/java/top/windysky/minecarttrainsfork/manager/TrainManager.java
+++ b/src/main/java/top/windysky/minecarttrainsfork/manager/TrainManager.java
@@ -3,9 +3,7 @@ package top.windysky.minecarttrainsfork.manager;
 import top.windysky.minecarttrainsfork.util.IChainableUtil;
 
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.vehicle.minecart.AbstractMinecart;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -54,10 +52,8 @@ public class TrainManager {
                     IChainableUtil.unsetChainedParentChild((IChainableUtil)parentCart, entityIChainable);
                     entity.spawnAtLocation((ServerLevel) entity.level(), new ItemStack(Items.IRON_CHAIN));
 
-                    for (Player p : entity.level().players()) {
-                        NetworkManager.sendRelationshipPayload(entity.getUUID(), null, (ServerPlayer) p);
-                        NetworkManager.sendRelationshipPayload(null, parentCart.getUUID(), (ServerPlayer) p);
-                    }
+                    NetworkManager.sendRelationshipPayload(entity.getUUID(), null, entity.level());
+                    NetworkManager.sendRelationshipPayload(null, parentCart.getUUID(), entity.level());
 
                     return;
                 }
@@ -67,10 +63,8 @@ public class TrainManager {
 
                     IChainableUtil.unsetChainedParentChild((IChainableUtil)parentCart, entityIChainable);
 
-                    for (Player p : entity.level().players()) {
-                        NetworkManager.sendRelationshipPayload(entity.getUUID(), null, (ServerPlayer) p);
-                        NetworkManager.sendRelationshipPayload(null, parentCart.getUUID(), (ServerPlayer) p);
-                    }
+                    NetworkManager.sendRelationshipPayload(entity.getUUID(), null, entity.level());
+                    NetworkManager.sendRelationshipPayload(null, parentCart.getUUID(), entity.level());
                 }
             }
 
@@ -79,10 +73,8 @@ public class TrainManager {
 
                 IChainableUtil.unsetChainedParentChild(entityIChainable, (IChainableUtil)childCart);
 
-                for (Player p : entity.level().players()) {
-                        NetworkManager.sendRelationshipPayload(childCart.getUUID(), null, (ServerPlayer) p);
-                        NetworkManager.sendRelationshipPayload(null, childCart.getUUID(), (ServerPlayer) p);
-                }
+                NetworkManager.sendRelationshipPayload(childCart.getUUID(), null, entity.level());
+                NetworkManager.sendRelationshipPayload(null, childCart.getUUID(), entity.level());
             }
 
             for (Entity otherEntity : entity.level().getEntities(entity, entity.getBoundingBox().inflate(0.1), entity::canCollideWith)) {

--- a/src/main/java/top/windysky/minecarttrainsfork/mixin/EntityMixin.java
+++ b/src/main/java/top/windysky/minecarttrainsfork/mixin/EntityMixin.java
@@ -24,7 +24,7 @@ public class EntityMixin {
         Entity self = (Entity)(Object)this;
 
         if (self instanceof AbstractMinecart) {
-            NetworkManager.sendRelationshipPayload(self.getUUID(), ((IChainableUtil) self).getParentUUID(), player);
+            NetworkManager.sendRelationshipPayload(self.getUUID(), ((IChainableUtil) self).getParentUUID(), player.level());
         }
     }
 
@@ -38,7 +38,7 @@ public class EntityMixin {
 
             if (!world.isClientSide()) {
                 ServerLevel serverWorld = (ServerLevel)world;
-                UnLinkUtil.unlinkHandle(icu, serverWorld, null);
+                UnLinkUtil.unlinkHandle(icu, serverWorld);
             }
         }
     }

--- a/src/main/java/top/windysky/minecarttrainsfork/util/UnLinkUtil.java
+++ b/src/main/java/top/windysky/minecarttrainsfork/util/UnLinkUtil.java
@@ -5,10 +5,8 @@ import java.util.UUID;
 import top.windysky.minecarttrainsfork.manager.NetworkManager;
 
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.vehicle.minecart.AbstractMinecart;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -17,7 +15,7 @@ public class UnLinkUtil {
 
     private UnLinkUtil() {}
 
-    public static void unlinkHandle(IChainableUtil icu, ServerLevel world, Player player) {
+    public static void unlinkHandle(IChainableUtil icu, ServerLevel world) {
         UUID parentUUID = icu.getParentUUID();
         UUID childUUID = icu.getChildUUID();
 
@@ -29,7 +27,7 @@ public class UnLinkUtil {
             if (parentEntity instanceof IChainableUtil parent) {
                 parent.setChildUUID(null);
 
-                NetworkManager.sendRelationshipPayload(null, parentEntity.getUUID(), (ServerPlayer) player);
+                NetworkManager.sendRelationshipPayload(null, parentEntity.getUUID(), world);
             }
         }
 
@@ -40,7 +38,7 @@ public class UnLinkUtil {
             if (childEntity instanceof IChainableUtil child) {
                 child.setParentUUID(null);
 
-                NetworkManager.sendRelationshipPayload(childEntity.getUUID(), null, (ServerPlayer) player);
+                NetworkManager.sendRelationshipPayload(childEntity.getUUID(), null, world);
             }
         }
 
@@ -53,8 +51,8 @@ public class UnLinkUtil {
         icu.setParentUUID(null);
         icu.setChildUUID(null);
 
-        NetworkManager.sendRelationshipPayload(((AbstractMinecart) icu).getUUID(), null, (ServerPlayer) player);
-        NetworkManager.sendRelationshipPayload(null, ((AbstractMinecart) icu).getUUID(), (ServerPlayer) player);
+        NetworkManager.sendRelationshipPayload(((AbstractMinecart) icu).getUUID(), null, world);
+        NetworkManager.sendRelationshipPayload(null, ((AbstractMinecart) icu).getUUID(), world);
 
         // 根据情况掉落铁链
         if (wasLinked && icu instanceof Entity entity) {
@@ -62,24 +60,12 @@ public class UnLinkUtil {
             double dy;
             double dz;
 
-            if (player == null) {
-                float yaw = entity.getYRot(); // 矿车朝向角度
-                double offset = 0.6;         // 偏移距离，控制掉落在轨道两侧
+            float yaw = entity.getYRot(); // 矿车朝向角度
+            double offset = 0.6;         // 偏移距离，控制掉落在轨道两侧
 
-                dx = Math.cos(Math.toRadians(yaw + 90)) * offset;
-                dy = 0.8;
-                dz = Math.sin(Math.toRadians(yaw + 90)) * offset;
-
-            } else {
-
-                // 掉落在玩家附近
-                double px = player.getX();
-                double pz = player.getZ();
-
-                dx = Math.signum(px - entity.getX()) * 0.5;
-                dy = 0.8;
-                dz = Math.signum(pz - entity.getZ()) * 0.5;
-            }
+            dx = Math.cos(Math.toRadians(yaw + 90)) * offset;
+            dy = 0.8;
+            dz = Math.sin(Math.toRadians(yaw + 90)) * offset;
 
             double x = entity.getX() + dx;
             double y = entity.getY() + dy;

--- a/src/main/resources/assets/minecart-trains-fork/lang/en_us.json
+++ b/src/main/resources/assets/minecart-trains-fork/lang/en_us.json
@@ -12,7 +12,7 @@
     "screen.minecart-trains-fork.ConfigEntryScreen.cancel": "Cancel",
 
     "screen.minecart-trains-fork.IllegalOperationScreen.title": "§cIllegal Operation",
-    "screen.minecart-trains-fork.IllegalOperationScreen.desc": ":( Don't be discouraged, this is not a bug.\n\nIt looks like you're playing a multiplayer game.\nYou cannot change the server configuration through this setting.\n\nIf you need to make changes, please contact the server administrator\nto modify the configuration file.\n§6... > config > minecart-trains-fork.json",
+    "screen.minecart-trains-fork.IllegalOperationScreen.desc": ":( Don't be discouraged, this is not a bug.\n\nIt looks like you're playing a multiplayer game.\nYou cannot change the server configuration through this setting.\n\nIf you need to make changes, please contact the server administrator\nto modify the configuration file.\n§6... > config > minecart-trains-fork-server.json",
     "screen.minecart-trains-fork.IllegalOperationScreen.yes": "OK",
     "screen.minecart-trains-fork.IllegalOperationScreen.no": "OK",
 

--- a/src/main/resources/assets/minecart-trains-fork/lang/en_us.json
+++ b/src/main/resources/assets/minecart-trains-fork/lang/en_us.json
@@ -46,7 +46,8 @@
     "text.autoconfig.minecart-trains-fork-client.option.lineWidth.@PrefixText": "Link Line",
     "text.autoconfig.minecart-trains-fork-client.option.lineWidth": "    Width of Link Line",
 
-    "text.autoconfig.minecart-trains-fork-client.option.headParticleType.@PrefixText": "Head Particle",
+    "text.autoconfig.minecart-trains-fork-client.option.alwaysRenderHeadParticle.@PrefixText": "Head Particle",
+    "text.autoconfig.minecart-trains-fork-client.option.alwaysRenderHeadParticle": "    Always Render Head Particle",
     "text.autoconfig.minecart-trains-fork-client.option.headParticleType": "    Selected Custom Head Cart Particle",
     "text.autoconfig.minecart-trains-fork-client.option.headParticleNumber": "    Number of Head Particle",
     "text.autoconfig.minecart-trains-fork-client.option.headParticleHeight": "    Height of Head Particle",


### PR DESCRIPTION
# To Do

- [x] Fix the issue where link particles still rendered when Cloth Config API was not present.
- [x] Fix the issue where the connection information used for rendering was not synchronized in multiplayer mode.
- [x] Fix the path name in the entrance interception prompt in multiplayer mode configuration.
- [x] Adjust the default rendering height of the leading cart particles.
- [x] Refactor the method sendRelationshipPayload.
- [x] Add the function to render lead cart particles conditionally.
- [ ] Fix the issue of child carts information being lost after rejoining the world.